### PR TITLE
remove broken sharedVariables and total bytes sent stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ server
 # Ignore any text editor backups
 *~
 
-
+*.swp

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ On a Mac use this command to compile the server:
 `gcc server.c -o server`
 
 
-To run the server type ./server into a terminal that is in the directory where the executable file is located.
+To run the server type `./server` into a terminal that is in the directory where the executable file is located.
+
+You can also pass a number after ./server to indicate how many threads the server should use like: `./server 3` for 3 child-processes
 
 By default the server runs on port 2001, so to try it out navigate to
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ On a Linux system system simply use the makefile to compile the server.
 
 On a Mac use this command to compile the server:
 
-gcc cs241server.c –o cs241server
+`gcc server.c -o server`
 
 
 To run the server type ./server into a terminal that is in the directory where the executable file is located.

--- a/routes.c
+++ b/routes.c
@@ -1,0 +1,15 @@
+typedef struct {
+  char* (*routeFnPtr)(int);
+  char *routename;
+} route;
+
+char* state(int a)
+{
+    return "{\"status\":1}";
+}
+
+const int routeCount = 1;
+route stateR = { .routeFnPtr = &state, .routename = "/state.json"};
+const route *routes[routeCount] = {
+  &stateR
+};

--- a/routes.c
+++ b/routes.c
@@ -3,6 +3,11 @@ typedef struct {
   char *routename;
 } route;
 
+// TO ADD A ROUTE:
+// 1. define a function that returns a char* here (that is the json content)
+// 2. add a route declaration at the bottom
+//    like: `route stateR = { .routeFnPtr = &state, .routename = "/state.json"};`
+
 char* state(int a)
 {
     return "{\"status\":1}";

--- a/server.c
+++ b/server.c
@@ -403,7 +403,6 @@ int main(int argc, char *argv[]) {
                   contentType = "application/json";
                 }
                 headersize = printHeader(conn_s, details.returncode, contentType);
-                free(contentType);
                 
                 if (details.filename != NULL) {
                   // Print out the file they wanted

--- a/server.c
+++ b/server.c
@@ -285,6 +285,7 @@ int printHeader(int fd, int returncode)
         return strlen(header404);
         break;
     }
+    return -1;
 }
 
 
@@ -328,7 +329,7 @@ int main(int argc, char *argv[]) {
     } 
     
     // Size of the address
-    int addr_size = sizeof(servaddr);
+    unsigned int addr_size = sizeof(servaddr);
     
     // Sizes of data were sending out
     int headersize;


### PR DESCRIPTION
on Mac when I try to compile it fails:

```
tenari@Daniels-MBP C-Web-Server % gcc server.c -o server
server.c:299:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
server.c:306:5: error: implicit declaration of function 'pthread_mutex_lock' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    pthread_mutex_lock(&(*mempointer).mutexlock);
    ^
server.c:310:5: error: implicit declaration of function 'pthread_mutex_unlock' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    pthread_mutex_unlock(&(*mempointer).mutexlock);
    ^
server.c:310:5: note: did you mean 'pthread_mutex_lock'?
server.c:306:5: note: 'pthread_mutex_lock' declared here
    pthread_mutex_lock(&(*mempointer).mutexlock);
    ^
server.c:380:5: error: implicit declaration of function 'pthread_mutex_init' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    pthread_mutex_init(&(*mempointer).mutexlock, NULL);
    ^
server.c:421:71: warning: passing 'int *' to parameter of type 'socklen_t *' (aka 'unsigned int *') converts between pointers to integer types with different
      sign [-Wpointer-sign]
                conn_s = accept(list_s, (struct sockaddr *)&servaddr, &addr_size);
                                                                      ^~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/sys/socket.h:691:73: note: passing argument to parameter here
int     accept(int, struct sockaddr * __restrict, socklen_t * __restrict)
                                                                        ^
2 warnings and 3 errors generated.
```

and since I didn't care about a running count of bytes sent I just yanked all that stuff out